### PR TITLE
Comment out error message handling in login flow

### DIFF
--- a/src/main/java/pages/LoginPage.java
+++ b/src/main/java/pages/LoginPage.java
@@ -21,8 +21,8 @@ public class LoginPage {
 	@FindBy(xpath = "//input[@type='submit']")
 	WebElement loginButton;
 
-	@FindBy(xpath = "//div[contains(text(),'Warning: No match')]")
-	WebElement errorMessage;
+//	@FindBy(xpath = "//div[contains(text(),'Warning: No match')]")
+//	WebElement errorMessage;
 	
 	@FindBy(xpath = "//a[contains(text(),'Edit Account')]")
 	WebElement editAccountLink;
@@ -83,10 +83,10 @@ public class LoginPage {
 		return presenceOfHomeLink;
 	}
 	
-	public String getErrorMessage() {		
-		if(errorMessage.isDisplayed()==true)
-			return errorMessage.getText();
-		else
-			return null;
-	}
+//	public String getErrorMessage() {		
+//		if(errorMessage.isDisplayed()==true)
+//			return errorMessage.getText();
+//		else
+//			return null;
+//	}
 }

--- a/src/test/java/tests/LoginTest.java
+++ b/src/test/java/tests/LoginTest.java
@@ -60,9 +60,9 @@ public class LoginTest extends BaseTest {
 			softAssert.assertEquals(loginPage.checkPresenceOfEditAccountLink(), true);
 		}
 		else {
-			test.fail("Login Failed. Error Message received: "+loginPage.getErrorMessage());
-			Log.error("Login Failed. Error Message received: "+loginPage.getErrorMessage());
-			Assert.fail("Login Failed. Error Message received: "+loginPage.getErrorMessage());
+			test.fail("Login Failed. Error Message received");
+			Log.error("Login Failed. Error Message received");
+			Assert.fail("Login Failed. Error Message received");
 		}		
 		
 		softAssert.assertAll();


### PR DESCRIPTION
The error message WebElement and its getter method in LoginPage have been commented out, and related calls in LoginTest have been updated to remove error message details from failure logs. This may be in preparation for refactoring or due to changes in the application's error handling.